### PR TITLE
fix: PinInput 브라우저 자동 완성 막음, 로그아웃 시 바로 캐시 삭제로 발생하는 깜빡임 막기 위해 브라우저에서 홈…

### DIFF
--- a/src/components/input/PinInput.tsx
+++ b/src/components/input/PinInput.tsx
@@ -56,6 +56,7 @@ const PinInput = forwardRef<HTMLInputElement, PinInputProps>(
               value={value[i] || ""}
               onChange={(e) => handleChange(i, e.target.value)}
               onKeyDown={(e) => handleKeyDown(i, e)}
+              autoComplete="new-password"
             />
           ))}
         </div>

--- a/src/features/user/pages/ProfilePage.tsx
+++ b/src/features/user/pages/ProfilePage.tsx
@@ -49,8 +49,10 @@ function ProfilePage() {
     "read",
     currentTab === "read",
   );
-  const { data: communityData, isLoading: isCommunityLoading } =
-    useReadDiaries("community", currentTab === "community");
+  const { data: communityData, isLoading: isCommunityLoading } = useReadDiaries(
+    "community",
+    currentTab === "community",
+  );
   const { data: writtenData, isLoading: isWrittenLoading } =
     useWrittenDiaries();
 
@@ -74,7 +76,8 @@ function ProfilePage() {
   function handleLogout() {
     logout(undefined, {
       onSettled: () => {
-        navigate(PATHS.HOME);
+        //브라우저 레벨에서 홈으로 즉시 새로고침하여 앱 상태를 완전히 초기화
+        window.location.replace(PATHS.HOME);
       },
     });
   }


### PR DESCRIPTION
…으로 새로고침

### 🧩 작업 개요
<!-- 어떤 작업을 했는지 간단히 정리해주세요 -->
- PinInput 브라우저 자동 완성 막음
- 로그아웃 시 바로 캐시 삭제로 발생하는 연쇄작용 깜빡임 막기 위해 브라우저에서 홈으로 랜딩
### ✨ 주요 변경 사항
<!-- 코드 변경 요약. 필요한 경우 코드블록이나 설명 추가 -->

### 🔗 관련 이슈
close #

### 🧠 기타 참고 사항
<!-- 참고해야 할 내용이나 남겨두고 싶은 회고 등 -->
