### PR TITLE
fix: 편지 본문 입력 시 캐럿을 가시 영역으로 스크롤 + 헤더 로그인 버튼 제거

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
 import Button from "../button/Button";
 import Menu from "../../assets/icons/Menu";
@@ -58,20 +58,13 @@ const Header = () => {
           </button>
         )}
 
-        {!shouldHideButton &&
-          (loggedIn ? (
-            isAdmin && (
-              <div className={classes.userArea}>
-                <Button alwaysHoverStyle onClick={handleAdmin}>
-                  관리자
-                </Button>
-              </div>
-            )
-          ) : (
-            <Link to={PATHS.LOGIN}>
-              <Button alwaysHoverStyle>로그인하기</Button>
-            </Link>
-          ))}
+        {!shouldHideButton && loggedIn && isAdmin && (
+          <div className={classes.userArea}>
+            <Button alwaysHoverStyle onClick={handleAdmin}>
+              관리자
+            </Button>
+          </div>
+        )}
       </header>
 
       <SideDrawer

--- a/src/features/post/pages/PostWritePage.tsx
+++ b/src/features/post/pages/PostWritePage.tsx
@@ -13,6 +13,7 @@ import TagSelectScreen from "../components/tag/TagSelectScreen";
 import iconUp from "../../../assets/icons/icon_up.svg";
 import iconDown from "../../../assets/icons/icon_down.svg";
 import iconMailman from "../../../assets/icons/icon_mailman.svg";
+import { getCaretOffsetTop } from "../utils/textareaCaret";
 
 type Step = "to" | "body" | "from";
 
@@ -154,6 +155,27 @@ function PostWritePage() {
     );
   }
 
+  // 본문 캐럿(커서)이 가시 영역에 보이도록 cardWrap을 스크롤.
+  // 자동 확장 textarea는 내부 스크롤이 없어 바깥 컨테이너를 캐럿에 맞춘다.
+  function scrollCaretIntoView() {
+    const ta = bodyRef.current;
+    const wrap = cardWrapRef.current;
+    if (!ta || !wrap) return;
+
+    const lineH = parseFloat(window.getComputedStyle(ta).lineHeight) || 40;
+    const caretY = getCaretOffsetTop(ta);
+    const taTop = ta.getBoundingClientRect().top;
+    const wrapRect = wrap.getBoundingClientRect();
+    const caretTop = taTop + caretY;
+    const caretBottom = caretTop + lineH;
+
+    if (caretBottom > wrapRect.bottom - lineH) {
+      wrap.scrollTop += caretBottom - (wrapRect.bottom - lineH);
+    } else if (caretTop < wrapRect.top + lineH) {
+      wrap.scrollTop -= wrapRect.top + lineH - caretTop;
+    }
+  }
+
   // 진입 안내 서브타이틀 1회 재생 (2단계). 이미 본 필드면 재생 안 함
   function playIntro(field: "to" | "body") {
     if (introDoneRef.current[field]) {
@@ -183,13 +205,12 @@ function PostWritePage() {
   function onFocusField(field: Step) {
     setStep(field);
     setFocused(true);
-    const el =
-      field === "to"
-        ? toRef.current
-        : field === "body"
-          ? bodyRef.current
-          : fromRef.current;
-    revealField(el);
+    if (field === "body") {
+      // 본문은 캐럿 위치 기준으로 스크롤 (전체 중앙 정렬 시 캐럿이 가려질 수 있음)
+      requestAnimationFrame(scrollCaretIntoView);
+    } else {
+      revealField(field === "to" ? toRef.current : fromRef.current);
+    }
     if (field === "from") hideSubtitle();
     else playIntro(field);
   }
@@ -199,7 +220,10 @@ function PostWritePage() {
     if (!ta) return;
     ta.focus();
     const p = Math.max(0, Math.min(pos, ta.value.length));
-    requestAnimationFrame(() => ta.setSelectionRange(p, p));
+    requestAnimationFrame(() => {
+      ta.setSelectionRange(p, p);
+      scrollCaretIntoView();
+    });
   }
 
   // 위/아래 버튼: 커서를 한 줄 위/아래로 이동 (편집은 커서 위치에서).
@@ -235,6 +259,7 @@ function PostWritePage() {
       const prevStart = val.lastIndexOf("\n", lineStart - 2) + 1;
       const newPos = Math.min(prevStart + col, lineStart - 1);
       ta.setSelectionRange(newPos, newPos);
+      requestAnimationFrame(scrollCaretIntoView);
     } else {
       const lineEnd = val.indexOf("\n", pos);
       if (lineEnd === -1) {
@@ -250,6 +275,7 @@ function PostWritePage() {
       const nextEnd = nextNl === -1 ? val.length : nextNl;
       const newPos = Math.min(nextStart + col, nextEnd);
       ta.setSelectionRange(newPos, newPos);
+      requestAnimationFrame(scrollCaretIntoView);
     }
   }
 
@@ -269,11 +295,8 @@ function PostWritePage() {
     el.style.height = "auto";
     el.style.height = `${el.scrollHeight}px`;
     hideSubtitle();
-    // 최신 입력 줄이 보이도록 아래로 스크롤
-    requestAnimationFrame(() => {
-      const wrap = cardWrapRef.current;
-      if (wrap) wrap.scrollTop = wrap.scrollHeight;
-    });
+    // 입력 중인 캐럿 줄이 보이도록 스크롤
+    requestAnimationFrame(scrollCaretIntoView);
   }
 
   function handleSubmit(tag: PostTag) {

--- a/src/features/post/utils/textareaCaret.ts
+++ b/src/features/post/utils/textareaCaret.ts
@@ -1,0 +1,52 @@
+// textarea 캐럿(커서)의 상단 오프셋(px)을 숨김 미러 엘리먼트로 측정한다.
+// 자동 확장되는 textarea는 내부 스크롤이 없어, 바깥 컨테이너를 캐럿 위치에
+// 맞춰 스크롤하려면 캐럿의 y좌표가 필요하다.
+const MIRROR_PROPS = [
+  "boxSizing",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "borderTopWidth",
+  "borderRightWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "lineHeight",
+  "letterSpacing",
+  "textTransform",
+  "wordBreak",
+  "overflowWrap",
+] as const;
+
+export function getCaretOffsetTop(ta: HTMLTextAreaElement): number {
+  const style = window.getComputedStyle(ta);
+  const mirror = document.createElement("div");
+  const s = mirror.style;
+
+  s.position = "absolute";
+  s.top = "0";
+  s.left = "-9999px";
+  s.visibility = "hidden";
+  s.whiteSpace = "pre-wrap";
+  s.overflowWrap = "break-word";
+  s.width = `${ta.clientWidth}px`;
+  MIRROR_PROPS.forEach((p) => {
+    s[p] = style[p];
+  });
+
+  const caret = ta.selectionStart ?? ta.value.length;
+  mirror.textContent = ta.value.slice(0, caret);
+  // 캐럿 위치 마커 (zero-width space)
+  const marker = document.createElement("span");
+  marker.textContent = "​";
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const top = marker.offsetTop;
+  document.body.removeChild(mirror);
+  return top;
+}


### PR DESCRIPTION
### 🧩 작업 개요
<!-- 어떤 작업을 했는지 간단히 정리해주세요 -->
- 본문 textarea 자동확장으로 커서가 화면 밖으로 잘리던 문제 수정: 스크롤 기준을 맨 아래 → 캐럿 위치로 변경(scrollCaretIntoView)
- textareaCaret 유틸: 미러 엘리먼트로 캐럿 y오프셋 측정
- 헤더 우측 로그인하기 버튼 제거(관리자 버튼은 유지)

### ✨ 주요 변경 사항
<!-- 코드 변경 요약. 필요한 경우 코드블록이나 설명 추가 -->

### 🔗 관련 이슈
close #

### 🧠 기타 참고 사항
<!-- 참고해야 할 내용이나 남겨두고 싶은 회고 등 -->
