### PR TITLE
feat: 편지 작성에서 이미지 첨부 → 본문 자리 캐러셀(이미지 편지)

### DIFF
--- a/src/features/post/components/card/CardListContainer.module.css
+++ b/src/features/post/components/card/CardListContainer.module.css
@@ -21,15 +21,3 @@
   justify-content: center;
   align-items: center;
 }
-
-@media (min-width: 768px) {
-  .cardList {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 1024px) {
-  .cardList {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}

--- a/src/features/post/components/write/ImageCarousel.module.css
+++ b/src/features/post/components/write/ImageCarousel.module.css
@@ -1,0 +1,88 @@
+.carousel {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-primary-100);
+}
+
+.track {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.track::-webkit-scrollbar {
+  display: none;
+}
+
+.slide {
+  position: relative;
+  flex: 0 0 100%;
+  scroll-snap-align: center;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary-100);
+}
+
+.image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: 0.8rem;
+  display: block;
+}
+
+/* 삭제(✕) 버튼 */
+.remove {
+  position: absolute;
+  top: 0.8rem;
+  right: 0.8rem;
+  width: 2.8rem;
+  height: 2.8rem;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 추가(＋) 슬라이드 */
+.addSlide {
+  border: 1px dashed var(--color-primary-300);
+  border-radius: 0.8rem;
+  color: var(--color-primary-400);
+  font-size: 3.2rem;
+  cursor: pointer;
+}
+
+.dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.2rem;
+}
+
+.dot {
+  width: 1.8rem;
+  height: 1.8rem;
+  padding: 0.6rem;
+  border: none;
+  background-color: var(--color-primary-300);
+  background-clip: content-box;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.dotActive {
+  background-color: var(--color-primary-700);
+}

--- a/src/features/post/components/write/ImageCarousel.tsx
+++ b/src/features/post/components/write/ImageCarousel.tsx
@@ -1,0 +1,83 @@
+import { useRef, useState } from "react";
+import type { LetterImage } from "../../hooks/useLetterImages";
+import { MAX_IMAGES } from "../../utils/imageUpload";
+import classes from "./ImageCarousel.module.css";
+
+type Props = {
+  images: LetterImage[];
+  onRemove: (index: number) => void;
+  onAdd: () => void;
+};
+
+/** 첨부 이미지 캐러셀 */
+export default function ImageCarousel({ images, onRemove, onAdd }: Props) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState(0);
+
+  const handleScroll = () => {
+    const track = trackRef.current;
+    if (!track || track.clientWidth === 0) return;
+    setActive(Math.round(track.scrollLeft / track.clientWidth));
+  };
+
+  const scrollToIndex = (i: number) => {
+    const track = trackRef.current;
+    if (!track) return;
+    track.scrollTo({ left: i * track.clientWidth, behavior: "smooth" });
+  };
+
+  const canAdd = images.length < MAX_IMAGES;
+
+  return (
+    <div className={classes.carousel}>
+      <div className={classes.track} ref={trackRef} onScroll={handleScroll}>
+        {images.map((img, i) => (
+          <div key={img.previewUrl} className={classes.slide}>
+            <img
+              src={img.previewUrl}
+              alt={`첨부 이미지 ${i + 1}`}
+              className={classes.image}
+            />
+            <button
+              type="button"
+              className={classes.remove}
+              onClick={() => onRemove(i)}
+              aria-label="이미지 삭제"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+
+        {canAdd && (
+          <button
+            type="button"
+            className={`${classes.slide} ${classes.addSlide}`}
+            onClick={onAdd}
+            aria-label="이미지 추가"
+          >
+            ＋
+          </button>
+        )}
+      </div>
+
+      {images.length > 1 && (
+        <div className={classes.dots}>
+          {images.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              className={`${classes.dot} ${
+                Math.min(active, images.length - 1) === i
+                  ? classes.dotActive
+                  : ""
+              }`}
+              onClick={() => scrollToIndex(i)}
+              aria-label={`${i + 1}번째 이미지로 이동`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/post/components/write/KeyboardAccessoryBar.module.css
+++ b/src/features/post/components/write/KeyboardAccessoryBar.module.css
@@ -24,6 +24,10 @@
   color: var(--color-primary-500);
   cursor: pointer;
 }
+.camera:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
 
 .nav {
   display: flex;

--- a/src/features/post/components/write/KeyboardAccessoryBar.tsx
+++ b/src/features/post/components/write/KeyboardAccessoryBar.tsx
@@ -9,6 +9,7 @@ type Props = {
   onDown: () => void;
   upDisabled?: boolean;
   downDisabled?: boolean;
+  cameraDisabled?: boolean;
 };
 
 /** 모바일 키보드 바로 위 액세서리 바 (이미지 등록 / 커서 위·아래 이동) */
@@ -18,6 +19,7 @@ export default function KeyboardAccessoryBar({
   onDown,
   upDisabled,
   downDisabled,
+  cameraDisabled,
 }: Props) {
   return (
     <div className={classes.bar}>
@@ -26,6 +28,7 @@ export default function KeyboardAccessoryBar({
         className={classes.camera}
         onPointerDown={(e) => e.preventDefault()}
         onClick={onCamera}
+        disabled={cameraDisabled}
         aria-label="이미지 등록"
       >
         <Camera />

--- a/src/features/post/hooks/useLetterImages.ts
+++ b/src/features/post/hooks/useLetterImages.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useToast } from "../../../contexts/ToastContext";
+import {
+  MAX_IMAGES,
+  MAX_TOTAL_BYTES,
+  ImagePrepareError,
+  prepareUploadFile,
+  formatMB,
+} from "../utils/imageUpload";
+
+export type LetterImage = {
+  file: File;
+  previewUrl: string;
+};
+
+/**
+ * 편지 첨부 이미지 상태 관리(검증·용량 제한·미리보기 URL 정리).
+ * PostImagePage의 파일 추가/삭제 로직을 재사용 가능한 훅으로 추출.
+ */
+export function useLetterImages() {
+  const [images, setImages] = useState<LetterImage[]>([]);
+  const { showToast } = useToast();
+  const imagesRef = useRef<LetterImage[]>([]);
+
+  useEffect(() => {
+    imagesRef.current = images;
+  }, [images]);
+
+  // 언마운트 시 남은 미리보기 URL 해제 (모바일 대용량 사진 메모리 정리)
+  useEffect(
+    () => () => {
+      imagesRef.current.forEach((item) => URL.revokeObjectURL(item.previewUrl));
+    },
+    [],
+  );
+
+  const addFiles = useCallback(
+    (files: File[]) => {
+      if (!files.length) return;
+
+      const remainingSlots = MAX_IMAGES - images.length;
+      if (remainingSlots <= 0) {
+        showToast(`사진은 최대 ${MAX_IMAGES}장까지 등록할 수 있어요.`, "cancel");
+        return;
+      }
+
+      try {
+        const prepared = files
+          .slice(0, remainingSlots)
+          .map((file) => prepareUploadFile(file));
+
+        const totalSize = [...images.map((i) => i.file), ...prepared].reduce(
+          (sum, file) => sum + file.size,
+          0,
+        );
+        if (totalSize > MAX_TOTAL_BYTES) {
+          showToast(
+            `전체 사진 용량은 ${formatMB(MAX_TOTAL_BYTES)}MB 이하만 등록할 수 있어요.`,
+            "cancel",
+          );
+          return;
+        }
+
+        const added = prepared.map((file) => ({
+          file,
+          previewUrl: URL.createObjectURL(file),
+        }));
+        setImages((prev) => [...prev, ...added]);
+      } catch (error) {
+        const message =
+          error instanceof ImagePrepareError
+            ? error.message
+            : "파일을 불러오지 못했어요. 다시 선택해주세요.";
+        showToast(message, "cancel");
+      }
+    },
+    [images, showToast],
+  );
+
+  const removeImage = useCallback((index: number) => {
+    setImages((prev) => {
+      if (!prev[index]) return prev;
+      URL.revokeObjectURL(prev[index].previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
+  }, []);
+
+  const clearImages = useCallback(() => {
+    setImages((prev) => {
+      prev.forEach((item) => URL.revokeObjectURL(item.previewUrl));
+      return [];
+    });
+  }, []);
+
+  return {
+    images,
+    addFiles,
+    removeImage,
+    clearImages,
+    hasImages: images.length > 0,
+  };
+}

--- a/src/features/post/pages/PostWritePage.module.css
+++ b/src/features/post/pages/PostWritePage.module.css
@@ -103,6 +103,64 @@
   color: var(--color-primary-400);
 }
 
+/* 이미지 첨부 파일 피커 (숨김) */
+.hiddenFileInput {
+  display: none;
+}
+
+/* 이미지 편지 모드: To(가운데·로즈) / 이미지 / From(밑줄), 화면 채움 */
+.imageLetter {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+  padding: 0.8rem 0;
+}
+.imgTo {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0.4rem;
+  color: var(--color-letter-line);
+  font-family: var(--c1-font-family);
+  font-weight: var(--c1-font-weight);
+  font-size: var(--c1-font-size);
+  letter-spacing: var(--c1-font-letter-spacing);
+}
+.imgToLabel {
+  flex-shrink: 0;
+}
+.imgToInput {
+  min-width: 0;
+  max-width: 70%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  text-align: center;
+}
+.imgToInput::placeholder {
+  color: var(--color-letter-line);
+  opacity: 0.5;
+}
+.imgArea {
+  flex: 1;
+  min-height: 24rem;
+  display: flex;
+}
+/* From: 좌측 정렬 + 로즈 밑줄 */
+.imgFrom {
+  margin: 0;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--color-letter-line);
+  font-family: var(--t3-font-family);
+  font-weight: var(--t3-font-weight);
+  font-size: 1.5rem;
+  color: var(--color-primary-700);
+}
+
 /* Letter의 .to/.from 줄 위에 입력을 flex로 배치 */
 .lineRow {
   display: flex;

--- a/src/features/post/pages/PostWritePage.tsx
+++ b/src/features/post/pages/PostWritePage.tsx
@@ -1,20 +1,28 @@
 import { useEffect, useRef, useState } from "react";
+import { isAxiosError } from "axios";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
 import classes from "./PostWritePage.module.css";
 import letter from "../components/letter/Letter.module.css";
 import { PATHS } from "../../../constants/path";
 import { useCreatePost } from "../hooks/useCreatePost";
+import { postApi } from "../api/post";
 import { SUBMIT_LOADING_MESSAGE } from "../../../constants/messages";
 import type { tags as PostTag } from "../types/tags";
 import Menu from "../../../assets/icons/Menu";
 import SideDrawer from "../../../components/drawer/SideDrawer";
 import TagSelectScreen from "../components/tag/TagSelectScreen";
+import Button from "../../../components/button/Button";
+import BottomSheet from "../../../components/bottomSheet/BottomSheet";
 import iconMailman from "../../../assets/icons/icon_mailman.svg";
 import { getCaretOffsetTop } from "../utils/textareaCaret";
+import { ACCEPTED_IMAGE_INPUT, compressForUpload } from "../utils/imageUpload";
 import { useVisualViewport } from "../../../hooks/useVisualViewport";
 import { useLetterDraft } from "../hooks/useLetterDraft";
 import { useFieldIntro } from "../hooks/useFieldIntro";
+import { useLetterImages } from "../hooks/useLetterImages";
+import { useToast } from "../../../contexts/ToastContext";
 import KeyboardAccessoryBar from "../components/write/KeyboardAccessoryBar";
+import ImageCarousel from "../components/write/ImageCarousel";
 
 type Step = "to" | "body" | "from";
 
@@ -43,6 +51,13 @@ function PostWritePage() {
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const fromRef = useRef<HTMLInputElement>(null);
   const cardWrapRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 첨부 이미지(이미지 편지 모드)
+  const { images, addFiles, removeImage, hasImages } = useLetterImages();
+  const [uploading, setUploading] = useState(false);
+  const [confirmConvert, setConfirmConvert] = useState(false);
+  const { showToast } = useToast();
 
   const { mutateAsync, isPending } = useCreatePost({
     onSuccess: (data, vars) => {
@@ -205,7 +220,83 @@ function PostWritePage() {
     requestAnimationFrame(scrollCaretIntoView);
   }
 
+  const openPicker = () => fileInputRef.current?.click();
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = "";
+    addFiles(files);
+  }
+
+  // 카메라 클릭: 본문 텍스트가 있으면(이미지 없음) 전환 확인 후, 아니면 바로 피커
+  function handleCameraClick() {
+    if (!hasImages && body.trim().length > 0) {
+      setConfirmConvert(true);
+      return;
+    }
+    openPicker();
+  }
+
+  function confirmConvertToImage() {
+    setConfirmConvert(false);
+    setBody(""); // 이미지 편지로 전환 → 본문 텍스트 비움
+    openPicker();
+  }
+
+  // 이미지 편지 제출: /post-images 로 to/from/tags + 파일(압축)
+  async function submitImagePost(tag: PostTag) {
+    if (uploading) return;
+    setUploading(true);
+    try {
+      const compressed = await Promise.all(
+        images.map((img) => compressForUpload(img.file)),
+      );
+      const data = await postApi.createImagePost(compressed, {
+        to: to.trim() || undefined,
+        from: from.trim() || undefined,
+        tags: [tag],
+      });
+      clearDraft();
+      setShowTagScreen(false);
+      navigate(PATHS.POST_SUBMIT_TYPE("image"), {
+        replace: true,
+        state: {
+          type: "image",
+          tags: [tag],
+          showCalendar: data.showCalendar && !!data.calendar,
+          streakState:
+            data.showCalendar && data.calendar
+              ? {
+                  calendar: data.calendar,
+                  coin: data.coin,
+                  totalPosts: data.totalPosts,
+                  postId: data.postId,
+                  tags: [tag],
+                }
+              : undefined,
+          stayMs: 1600,
+          message: SUBMIT_LOADING_MESSAGE,
+        },
+      });
+    } catch (error) {
+      // 413: 서버 업로드 용량 초과 → 원인을 알 수 있게 안내
+      if (isAxiosError(error) && error.response?.status === 413) {
+        showToast(
+          "사진 용량이 너무 커요. 장수를 줄이거나 더 작은 사진으로 다시 시도해주세요.",
+          "cancel",
+        );
+      } else {
+        showToast("사진 업로드에 실패했어요. 다시 시도해주세요.", "cancel");
+      }
+      setUploading(false);
+    }
+  }
+
   function handleSubmit(tag: PostTag) {
+    if (hasImages) {
+      void submitImagePost(tag);
+      return;
+    }
     if (isPending) return;
     void mutateAsync({
       to: to.trim() || undefined,
@@ -224,7 +315,7 @@ function PostWritePage() {
       <TagSelectScreen
         onSubmit={handleSubmit}
         onClose={() => setShowTagScreen(false)}
-        submitting={isPending}
+        submitting={isPending || uploading}
       />
     );
   }
@@ -234,6 +325,8 @@ function PostWritePage() {
   const bodyRemaining = BODY_MIN - bodyCount;
   const bodyCountLabel =
     bodyRemaining > 0 ? `${bodyRemaining}자 남음` : `${-bodyRemaining}자 넘음`;
+  // 접수 가능: 텍스트는 30자 이상, 이미지는 1장 이상
+  const canSubmit = hasImages ? images.length > 0 : bodyOk;
   const showReceipt = from.trim().length > 0;
 
   return (
@@ -257,7 +350,7 @@ function PostWritePage() {
             type="button"
             className={classes.receipt}
             onClick={() => setShowTagScreen(true)}
-            disabled={isPending || !bodyOk}
+            disabled={isPending || uploading || !canSubmit}
           >
             <img src={iconMailman} alt="" className={classes.receiptIcon} />
             <span>접수</span>
@@ -277,41 +370,32 @@ function PostWritePage() {
       </div>
 
       <div className={classes.cardWrap} ref={cardWrapRef}>
-        {/* 편지지 양식은 Letter.module.css(줄노트/타이포/여백) 재활용 */}
-        <div className={letter.paper}>
-          <div className={letter.sheet}>
-            <p className={`${letter.to} ${classes.lineRow}`}>
-              <span className={classes.prefixLabel}>To.</span>
+        {hasImages ? (
+          /* 이미지 편지: To(가운데·로즈) / 이미지 캐러셀 / From(밑줄) */
+          <div className={classes.imageLetter}>
+            <p className={classes.imgTo}>
+              <span className={classes.imgToLabel}>To</span>
               <input
                 ref={toRef}
-                className={classes.inlineInput}
+                className={classes.imgToInput}
                 value={to}
-                onChange={(e) => {
-                  setTo(e.target.value);
-                  hideSubtitle();
-                }}
+                onChange={(e) => setTo(e.target.value)}
                 onFocus={() => onFocusField("to")}
                 onBlur={handleFieldBlur}
-                placeholder="혼자라고 느끼는 사람에게"
+                placeholder="..."
                 autoComplete="off"
-                enterKeyHint="next"
               />
             </p>
 
-            <div className={`${letter.body} ${classes.bodyRow}`}>
-              <textarea
-                ref={bodyRef}
-                className={classes.inlineBody}
-                value={body}
-                onChange={handleBodyChange}
-                onFocus={() => onFocusField("body")}
-                onBlur={handleFieldBlur}
-                placeholder="지금 떠오르는 말부터 적어보세요"
-                rows={1}
+            <div className={classes.imgArea}>
+              <ImageCarousel
+                images={images}
+                onRemove={removeImage}
+                onAdd={openPicker}
               />
             </div>
 
-            <p className={`${letter.from} ${classes.lineRow}`}>
+            <p className={`${classes.imgFrom} ${classes.lineRow}`}>
               <span className={classes.prefixLabel}>From.</span>
               <input
                 ref={fromRef}
@@ -325,23 +409,115 @@ function PostWritePage() {
               />
             </p>
           </div>
-        </div>
+        ) : (
+          <>
+            {/* 편지지 양식은 Letter.module.css(줄노트/타이포/여백) 재활용 */}
+            <div className={letter.paper}>
+              <div className={letter.sheet}>
+                <p className={`${letter.to} ${classes.lineRow}`}>
+                  <span className={classes.prefixLabel}>To.</span>
+                  <input
+                    ref={toRef}
+                    className={classes.inlineInput}
+                    value={to}
+                    onChange={(e) => {
+                      setTo(e.target.value);
+                      hideSubtitle();
+                    }}
+                    onFocus={() => onFocusField("to")}
+                    onBlur={handleFieldBlur}
+                    placeholder="혼자라고 느끼는 사람에게"
+                    autoComplete="off"
+                    enterKeyHint="next"
+                  />
+                </p>
 
-        {/* 본문 글자수: 30자 남음 → 0자 넘음 → 1자 넘음 ... */}
-        <p className={classes.charCount} aria-live="polite">
-          {bodyCountLabel}
-        </p>
+                <div className={`${letter.body} ${classes.bodyRow}`}>
+                  <textarea
+                    ref={bodyRef}
+                    className={classes.inlineBody}
+                    value={body}
+                    onChange={handleBodyChange}
+                    onFocus={() => onFocusField("body")}
+                    onBlur={handleFieldBlur}
+                    placeholder="지금 떠오르는 말부터 적어보세요"
+                    rows={1}
+                  />
+                </div>
+
+                <p className={`${letter.from} ${classes.lineRow}`}>
+                  <span className={classes.prefixLabel}>From.</span>
+                  <input
+                    ref={fromRef}
+                    className={classes.inlineInput}
+                    value={from}
+                    onChange={(e) => setFrom(e.target.value)}
+                    onFocus={() => onFocusField("from")}
+                    onBlur={handleFieldBlur}
+                    placeholder="지금의 나를 한 문장으로"
+                    autoComplete="off"
+                  />
+                </p>
+              </div>
+            </div>
+
+            {/* 본문 글자수: 30자 남음 → 0자 넘음 → 1자 넘음 ... */}
+            <p className={classes.charCount} aria-live="polite">
+              {bodyCountLabel}
+            </p>
+          </>
+        )}
       </div>
+
+      {/* 이미지 첨부 파일 피커 (숨김) */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_IMAGE_INPUT}
+        multiple
+        className={classes.hiddenFileInput}
+        onChange={handleFileChange}
+      />
 
       {focused && (
         <KeyboardAccessoryBar
-          onCamera={() => navigate(PATHS.POST_NEW_IMAGE)}
+          onCamera={handleCameraClick}
           onUp={() => moveCaret(-1)}
           onDown={() => moveCaret(1)}
           upDisabled={step === "to"}
           downDisabled={step === "from"}
+          cameraDisabled={step !== "body"}
         />
       )}
+
+      {/* 본문 글이 있는데 이미지 첨부 시: 이미지 편지 전환 확인 */}
+      <BottomSheet
+        isOpen={confirmConvert}
+        onClose={() => setConfirmConvert(false)}
+        aria-labelledby="convert-title"
+      >
+        <BottomSheet.Title id="convert-title">
+          작성한 본문은 사라지고 이미지 편지로 전환돼요. 계속할까요?
+        </BottomSheet.Title>
+        <BottomSheet.Actions>
+          <Button
+            type="button"
+            variant="main"
+            state="active"
+            onClick={confirmConvertToImage}
+          >
+            이미지 편지로 전환
+          </Button>
+          <Button
+            type="button"
+            variant="sub"
+            state="default"
+            onClick={() => setConfirmConvert(false)}
+          >
+            취소
+          </Button>
+        </BottomSheet.Actions>
+      </BottomSheet>
     </div>
   );
 }

--- a/src/features/post/utils/imageUpload.ts
+++ b/src/features/post/utils/imageUpload.ts
@@ -6,10 +6,10 @@ export const MAX_TOTAL_BYTES = 300 * 1024 * 1024;
 export const ACCEPTED_IMAGE_INPUT =
   ".jpg,.jpeg,.png,.webp,.heic,.heif,image/jpeg,image/png,image/webp,image/heic,image/heif";
 
-// 업로드 전 클라이언트 압축
+// 업로드 전 클라이언트 압축 (서버 업로드 한도 대응으로 강하게)
 const COMPRESS_OPTIONS = {
-  maxSizeMB: 1,
-  maxWidthOrHeight: 1920,
+  maxSizeMB: 0.5,
+  maxWidthOrHeight: 1600,
   useWebWorker: true,
 };
 


### PR DESCRIPTION
### 🧩 작업 개요
<!-- 어떤 작업을 했는지 간단히 정리해주세요 -->
- 본문 활성 시 카메라 활성, 인라인 파일 피커로 이미지 첨부 가능, 이미지 캐러셀로 다수 이미지 등록 가능
- 제출 분기: 이미지는 /post-images(to/from/tags+파일), 텍스트는 기존 create
- useLetterImages 훅으로 첨부 상태 분리(imageUpload 유틸 재사용)
- 업로드 압축 강화(0.5MB/1600px), 413 시 용량 초과 안내 토스트
- 작성/열람 일기 카드 목록 항상 1열 세로 정렬
- 마이페이지 버튼 정리
- 글 작성 페이지 ux 정리 


### ✨ 주요 변경 사항
<!-- 코드 변경 요약. 필요한 경우 코드블록이나 설명 추가 -->

### 🔗 관련 이슈
close #

### 🧠 기타 참고 사항
<!-- 참고해야 할 내용이나 남겨두고 싶은 회고 등 -->
